### PR TITLE
Fixed the lack of backups of calibration files 

### DIFF
--- a/pyptv_gui/calibration_gui.py
+++ b/pyptv_gui/calibration_gui.py
@@ -492,6 +492,7 @@ class calibration_gui(HasTraits):
         self.status_text="Orientation finished."
 
     def _button_orient_part_fired(self):
+        self.backup_ori_files()
         self.ptv.py_calibration(10)
         x1,y1,x2,y2=[],[],[],[]
         self.ptv.py_get_from_orient(x1,y1,x2,y2)
@@ -508,6 +509,7 @@ class calibration_gui(HasTraits):
         self.status_text="Orientation with particles finished."
 
     def _button_orient_dumbbell_fired(self):
+            self.backup_ori_files()
             print "Starting orientation from dumbbell"
             self.ptv.py_ptv_set_dumbbell(1)
             n_camera=len(self.camera)

--- a/pyptv_gui/calibration_gui.py
+++ b/pyptv_gui/calibration_gui.py
@@ -636,6 +636,8 @@ class calibration_gui(HasTraits):
             
         for f in calOriParams.img_ori:
             shutil.copyfile(f,f+'.bck')
+            g = f.replace('ori','addpar')
+            shutil.copyfile(g, g + '.bck')
 
     def restore_ori_files(self):
         # backup ORI/ADDPAR files to the backup_cal directory
@@ -645,6 +647,8 @@ class calibration_gui(HasTraits):
         for f in calOriParams.img_ori:
             print "restored %s " % f
             shutil.copyfile(f+'.bck',f)
+            g = f.replace('ori','addpar')
+            shutil.copyfile(g + '.bck', g)
 
     def protect_ori_files(self):
         # backup ORI/ADDPAR files to the backup_cal directory


### PR DESCRIPTION
When calibrating from dumbbells or particles the ori and addpar files were lost. now they're backed up with .bck extension in the same /cal folder and restored by the respective buttons. 