### PR TITLE
fixing the bug when cpar->num_cams < 4

### DIFF
--- a/src_c/jw_ptv.c
+++ b/src_c/jw_ptv.c
@@ -146,7 +146,7 @@ int init_proc_c()
     cpar = read_control_par("parameters/ptv.par");
     cpar->mm->nlay = 1;
     
-    for (i=0; i<4; i++)
+    for (i=0; i<cpar->num_cams; i++)
     {
         strncpy(img_cal[i], cpar->cal_img_base_name[i], 128);
     }
@@ -226,7 +226,7 @@ int start_proc_c()
     cpar = read_control_par("parameters/ptv.par");
     cpar->mm->nlay = 1;
     
-    for (i=0; i<4; i++)
+    for (i=0; i<cpar->num_cams; i++)
     {
         strncpy(img_cal[i], cpar->cal_img_base_name[i], 128);
     }


### PR DESCRIPTION
the bug was revealed with a single camera tracking case discussed on the forum. failed on Mac with strncpy() related segfault.