### PR TITLE
Update jw_ptv.c

### DIFF
--- a/src_c/jw_ptv.c
+++ b/src_c/jw_ptv.c
@@ -608,7 +608,7 @@ int calibration_proc_c (int sel)
             printf("\n after high pass inside detection");
             for (i = 0; i < cpar->num_cams; i++)
             {
-                copy_images (img[i], img0[i]);
+                memcpy(img0[i], img[i_img], imgsize);
             }
             
             /* target recognition */

--- a/src_c/jw_ptv.c
+++ b/src_c/jw_ptv.c
@@ -608,7 +608,7 @@ int calibration_proc_c (int sel)
             printf("\n after high pass inside detection");
             for (i = 0; i < cpar->num_cams; i++)
             {
-                memcpy(img0[i], img[i_img], imgsize);
+                memcpy(img0[i], img[i], imgsize);
             }
             
             /* target recognition */


### PR DESCRIPTION
solves critical bug created by copy_images ( ) that leads to segfault when Detection is pressed in Calibration 