### PR TITLE
this workaround for 1-2 cameras

### DIFF
--- a/pyptv_gui/pyptv_gui.py
+++ b/pyptv_gui/pyptv_gui.py
@@ -577,17 +577,17 @@ class TreeMenuHandler (Handler):
             # main loop - format image name, read it and call v.py_sequence_loop(..) for current step
             for i in range(seq_first,seq_last+1,stepshake):
                 seq_ch="%04d" % i
-                    
                 for j in range (n_camera):
                     img_name=base_name[j]+seq_ch
-                    print ("Setting image: ",img_name)
+                    print ("Setting image: %s" % img_name)
                     try:
                         temp_img=imread(img_name).astype(np.ubyte)
                     except:
                         print "Error reading file"
                            
                     ptv.py_set_img(temp_img,j)
-                    ptv.py_sequence_loop(0,i)
+                    
+                ptv.py_sequence_loop(0,i)
         else:
             print "Sequence by using "+extern_sequence
             sequence=seq.Sequence(ptv=ptv, exp1=info.object.exp1,camera_list=info.object.camera_list)
@@ -1080,7 +1080,7 @@ class MainGUI (HasTraits):
 
 
     def load_disp_image(self, img_name,j,display_only=False):
-        print ("Setting image: "+str(img_name))
+        print ("Setting image: %s" % str(img_name))
         temp_img=np.array([],dtype=np.ubyte)
         try:
             temp_img=imread(img_name).astype(np.ubyte)

--- a/src_c/draw.c
+++ b/src_c/draw.c
@@ -42,7 +42,11 @@ int trajectories_c(int i, control_par *cpar)
  
       fp1 = fopen (val, "r");
       
-  seq_par = read_sequence_par("parameters/sequence.par", cpar->num_cams);
+    if (cpar->num_cams < 3){
+        seq_par = read_sequence_par("parameters/sequence.par", 4);
+    } else {
+        seq_par = read_sequence_par("parameters/sequence.par", cpar->num_cams);
+    }
   color = ((double)(i - seq_par->first)) / ((double)(seq_par->last - 2 - seq_par->first));
       fscanf (fp1,"%d\n", &anz1);
       

--- a/src_c/jw_ptv.c
+++ b/src_c/jw_ptv.c
@@ -411,8 +411,6 @@ int detection_proc_c(char **image_names)
         /* reorganize target numbers */
         for (i=0; i<num[i_img]; i++)  pix[i_img][i].pnr = i;
     }
-    printf("pix.x01=%f\n",pix[0][0].x);
-	printf("pix.y01=%f\n",pix[0][0].y);
     
     sprintf (buf, "Number of detected particles per image");
     printf("%s\n", val);

--- a/src_c/orientation.c
+++ b/src_c/orientation.c
@@ -55,7 +55,11 @@ void prepare_eval (control_par *cpar, int *n_fix) {
     frame frm;
     frame_init(&frm, cpar->num_cams, MAX_TARGETS);
     
-	seq_par = read_sequence_par("parameters/sequence.par", cpar->num_cams);
+    if (cpar->num_cams < 3){
+        seq_par = read_sequence_par("parameters/sequence.par", 4);
+    } else {
+        seq_par = read_sequence_par("parameters/sequence.par", cpar->num_cams);
+    }
 
 	fpp = fopen ("parameters/dumbbell.par", "r");
     if (fpp){
@@ -119,7 +123,12 @@ void prepare_eval_shake(control_par *cpar) {
     frame frm;
     frame_init(&frm, cpar->num_cams, MAX_TARGETS);
     
-	seq_par = read_sequence_par("parameters/sequence.par", cpar->num_cams);
+    if (cpar->num_cams < 3){
+        seq_par = read_sequence_par("parametes/sequence.par", 4);
+    } else {
+        seq_par = read_sequence_par("parameters/sequence.par", cpar->num_cams);
+    }
+
 
 	fpp = fopen ("parameters/shaking.par", "r");
     fscanf (fpp,"%d\n", &seq_first);

--- a/src_c/peakfitting.c
+++ b/src_c/peakfitting.c
@@ -60,11 +60,8 @@ control_par *cpar;
   /* read image name, threshold and shape limits from parameter file */
 
 /*------------------------------------------------------------------------*/
-  printf("inside peak_fit_new\n");
   fpp = fopen(par_file,"r");
   if (fpp){
-  	printf("opened file %s", &par_file);
-  	printf("assigned file header %d", fpp);
   	fscanf (fpp, "%d", &gvthres[0]);      /* threshold for binarization 1.image */
   	fscanf (fpp, "%d", &gvthres[1]);      /* threshold for binarization 2.image */
   	fscanf (fpp, "%d", &gvthres[2]);      /* threshold for binarization 3.image */

--- a/src_c/segmentation.c
+++ b/src_c/segmentation.c
@@ -115,11 +115,8 @@ control_par *cpar;
   imy = cpar->imy;
 
   /* read image name, filter dimension and threshold from parameter file */
-  printf("inside targ_rec (segmentation.c) \n");
   fpp = fopen(par_file,"r");
   if (fpp){
-  	printf("opened file %s", &par_file);
-  	printf("assigned file header %d", fpp);
   	fscanf (fpp, "%d", &gvthres[0]);      /* threshold for binarization 1.image */
   	fscanf (fpp, "%d", &gvthres[1]);      /* threshold for binarization 2.image */
   	fscanf (fpp, "%d", &gvthres[2]);      /* threshold for binarization 3.image */
@@ -133,7 +130,7 @@ control_par *cpar;
   	fclose (fpp);
   }
   else{
-  	printf("problem opening %s\n", &par_file);
+  	printf("error opening %s in segmentation.c\n", &par_file);
   }
   /* give thres value refering to image number */
   thres=gvthres[nr];

--- a/src_c/tracking_run.c
+++ b/src_c/tracking_run.c
@@ -20,12 +20,11 @@ void tr_init(tracking_run *tr, char *seq_par_fname, char *tpar_fname,
     tr->tpar = read_track_par(tpar_fname);
     tr->vpar = read_volume_par(vpar_fname);
     tr->cpar = read_control_par(cpar_fname);
-    if (tr->cpar->num_cams == 1){
+    if (tr->cpar->num_cams < 3){
         tr->seq_par = read_sequence_par(seq_par_fname, 4);
     } else {
         tr->seq_par = read_sequence_par(seq_par_fname, tr->cpar->num_cams);
     }
-    
 }
 
 /* tr_free deallocates all data allocated inside a TrackingRun object (but NOT


### PR DESCRIPTION
fixes the bug with the openptv-python trying to read  the sequence par according to the seq->num_cams instead of 4 (backward compatible type)