### PR TITLE
fix the initial guess bug

### DIFF
--- a/src_c/jw_ptv.c
+++ b/src_c/jw_ptv.c
@@ -673,8 +673,9 @@ int calibration_proc_c (int sel)
                 nfix = k;
                 
                 /* read initial guess orientation from the ori files, no add params */
-                read_ori (&Ex[i], &I[i], &G[i], img_ori0[i], &(ap[i]), 
+                UPDATE_CALIBRATION(i, &Ex[i], &I[i], &G[i], img_ori0[i], &(ap[i]),
                     img_addpar0[i], "addpar.raw");
+                rotation_matrix(&(Ex[i]));
                 
                 /* presenting detected points by back-projection */
                 just_plot (Ex[i], I[i], G[i], ap[i], nfix, fix, i, cpar);


### PR DESCRIPTION
changed read_ori into the new UPDATE_CALIBRATION with rotation_matrix to have an updated ORI file read and copied for the update of the Plot initial guess