### PR TITLE
workaround of a button TraitsUI bug 

### DIFF
--- a/pyptv_gui/directory_editor.py
+++ b/pyptv_gui/directory_editor.py
@@ -20,10 +20,10 @@ class DirectoryEditorDialog ( HasTraits ):
 	view = View( 
 		dir_item,
 		title	  = 'Choose the Experiments directory',
-		buttons	  = ['OK'],
+		# buttons	  = ['OK'],
 		width=0.5,
-		resizable = True,
-		kind = 'modal'
+		resizable = True#,
+		# kind = 'modal'
 	)
 # Create the demo:
 # demo = DirectoryEditorDemo()


### PR DESCRIPTION
(fails on both wx and qt4) with the button ['OK'] interface in the Directory Selection Dialog 

this is not a solution, but a workaround, we need to dig deeper into Traits or update to TraitsUI 5 to get the solution