### PR TITLE
an awful hack to solve the tracking segfault

### DIFF
--- a/src_c/orientation.c
+++ b/src_c/orientation.c
@@ -55,7 +55,7 @@ void prepare_eval (control_par *cpar, int *n_fix) {
     frame frm;
     frame_init(&frm, cpar->num_cams, MAX_TARGETS);
     
-    if (cpar->num_cams < 3){
+    if (cpar->num_cams < 4){
         seq_par = read_sequence_par("parameters/sequence.par", 4);
     } else {
         seq_par = read_sequence_par("parameters/sequence.par", cpar->num_cams);
@@ -123,7 +123,7 @@ void prepare_eval_shake(control_par *cpar) {
     frame frm;
     frame_init(&frm, cpar->num_cams, MAX_TARGETS);
     
-    if (cpar->num_cams < 3){
+    if (cpar->num_cams < 4){
         seq_par = read_sequence_par("parametes/sequence.par", 4);
     } else {
         seq_par = read_sequence_par("parameters/sequence.par", cpar->num_cams);

--- a/src_c/tracking_run.c
+++ b/src_c/tracking_run.c
@@ -20,7 +20,7 @@ void tr_init(tracking_run *tr, char *seq_par_fname, char *tpar_fname,
     tr->tpar = read_track_par(tpar_fname);
     tr->vpar = read_volume_par(vpar_fname);
     tr->cpar = read_control_par(cpar_fname);
-    if (tr->cpar->num_cams < 3){
+    if (tr->cpar->num_cams < 4){ //awful hack until we revise openptv-python
         tr->seq_par = read_sequence_par(seq_par_fname, 4);
     } else {
         tr->seq_par = read_sequence_par(seq_par_fname, tr->cpar->num_cams);


### PR DESCRIPTION
 an awful hack to solve the tracking segfault for the less than 4 cameras parameters due to mismatch between liboptv and openptv-python parameter files should solve the issue #50 