### PR TITLE
Use highpass flag for the calibration pre-processing

### DIFF
--- a/src_c/jw_ptv.c
+++ b/src_c/jw_ptv.c
@@ -271,7 +271,7 @@ int pre_processing_c(int y_remap_mode)
 {
     int i_img, sup, i;
     
-    sprintf(val, "Filtering with Highpass");
+    printf("\n Highpass filtering \n");
     
     /* read support of unsharp mask */
     fpp = fopen ("parameters/unsharp_mask.par", "r");
@@ -593,10 +593,16 @@ int calibration_proc_c (int sel)
             
             
         case 2: // puts ("Detection procedure"); strcpy(val,"");
-            
-            printf("Detection procedure (without highpass, clean up your images) \n");
-            
-            /* Highpass Filtering is removed - edited pics do not work with the highpass */
+                        
+            /* Highpass Filtering */
+            if (cpar->hp_flag) {
+                pre_processing_c (cpar->chfield);
+                printf("\n Highpass switched on, flag is %d \n",cpar->hp_flag);
+                } 
+                else { 
+                    printf ("\n Highpass switched off, flag is %d \n",cpar->hp_flag); 
+                }
+
             // pre_processing_c (chfield);
             
             /* reset zoom values */

--- a/src_c/jw_ptv.c
+++ b/src_c/jw_ptv.c
@@ -594,10 +594,10 @@ int calibration_proc_c (int sel)
             
         case 2: // puts ("Detection procedure"); strcpy(val,"");
             
-            printf("Detection procedure\n");
+            printf("Detection procedure (without highpass, clean up your images) \n");
             
-            /* Highpass Filtering */
-            pre_processing_c (chfield);
+            /* Highpass Filtering is removed - edited pics do not work with the highpass */
+            // pre_processing_c (chfield);
             
             /* reset zoom values */
             for (i = 0; i < cpar->num_cams; i++)


### PR DESCRIPTION
Working on calibration with Claudio I have encountered a problem to get detections in the Gimp edited, clean pics with very plain background and very bright dots. The older versions didn't have high pass in the calibration procedure and worked with these photos, but not this version. I suggest to comment out the highpass and always clean and prepare the images for the calibration.