### PR TITLE
workaround for the Tracking with Display without actual images

### DIFF
--- a/pyptv_gui/pyptv_gui.py
+++ b/pyptv_gui/pyptv_gui.py
@@ -1092,7 +1092,10 @@ class MainGUI (HasTraits):
         try:
             temp_img = img_as_ubyte(imread(img_name))
         except:
-            print "Error reading file"
+            print("Error reading file, setting zero image")
+            h_img=self.exp1.active_params.m_params.imx
+            v_img=self.exp1.active_params.m_params.imy
+            temp_img = img_as_ubyte(np.zeros((h_img,v_img)))
         if not display_only:
             ptv.py_set_img(temp_img,j)
         if len(temp_img)>0:


### PR DESCRIPTION
this workaround allows to use track with display without images - if image doest not exist or not showing, an empty image will show up, instead of crushing.

One user case is our blob recorder - the real time image processing unit - there are no images at the end of the process. 